### PR TITLE
return generated dbml, make fs optional

### DIFF
--- a/src/generators/mysql.ts
+++ b/src/generators/mysql.ts
@@ -22,8 +22,9 @@ class MySqlGenerator extends BaseGenerator<MySqlSchema, AnyMySqlColumn> {
   }
 }
 
-export function mysqlGenerate<T>(options: Options<T>) {
+export function mysqlGenerate<T>(options: Options<T>): string {
   options.relational ||= false;
   const dbml = new MySqlGenerator(options.schema as MySqlSchema, options.relational).generate();
-  writeDBMLFile(dbml, options.out);
+  options.out && writeDBMLFile(dbml, options.out);
+  return dbml;
 }

--- a/src/generators/pg.ts
+++ b/src/generators/pg.ts
@@ -29,8 +29,9 @@ class PgGenerator extends BaseGenerator<PgSchema, AnyPgColumn> {
   }
 }
 
-export function pgGenerate<T>(options: Options<T>) {
+export function pgGenerate<T>(options: Options<T>): string {
   options.relational ||= false;
   const dbml = new PgGenerator(options.schema as PgSchema, options.relational).generate();
-  writeDBMLFile(dbml, options.out);
+  options.out && writeDBMLFile(dbml, options.out);
+  return dbml;
 }

--- a/src/generators/sqlite.ts
+++ b/src/generators/sqlite.ts
@@ -39,8 +39,9 @@ class SQLiteGenerator extends BaseGenerator<SQLiteSchema, AnySQLiteColumn> {
   }
 }
 
-export function sqliteGenerate<T>(options: Options<T>) {
+export function sqliteGenerate<T>(options: Options<T>): string {
   options.relational ||= false;
   const dbml = new SQLiteGenerator(options.schema as SQLiteSchema, options.relational).generate();
-  writeDBMLFile(dbml, options.out);
+  options.out && writeDBMLFile(dbml, options.out);
+  return dbml;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,7 +21,7 @@ export type AnyBuilder = {
 };
 export type Options<Schema> = {
   schema: Schema;
-  out: string;
+  out?: string;
   relational?: boolean;
 };
 


### PR DESCRIPTION
There are two noticeable interface changes
- `Options.out` has become optional instead of required
- return types of generate fns have become `string` instead of `void`

Both are non-breaking changes.

Resolves #8