### PR TITLE
Escape non-space characters

### DIFF
--- a/src/dbml.ts
+++ b/src/dbml.ts
@@ -18,7 +18,7 @@ export class DBML {
    * Escapes characters that aren't allowed in DBML surrounding the input with double quotes
    */
   public escapeSpaces(str: string) {
-    this.built += str.includes(' ') ? `"${str}"` : str;
+    this.built += /\W/.test(str) ? `"${str}"` : str;
     return this;
   }
 


### PR DESCRIPTION
Non-word characters other than just spaces also cause issues for me in enum values – e.g. `12/28`. If you wrap it – `"12/28"` – it works fine. 

Some other examples:

```javascript
/\W/.test('asdf')
false
/\W/.test('asdf/')
true
/\W/.test('asdf:')
true
/\W/.test('asdf ')
true
```