### PR TITLE
fix: Support new Postgres index API

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
     "vitest": "^0.34.3"
   },
   "dependencies": {
-    "drizzle-orm": "^0.29.0"
+    "drizzle-orm": "^0.31.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,13 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 dependencies:
   drizzle-orm:
-    specifier: ^0.29.0
-    version: 0.29.0
+    specifier: ^0.31.1
+    version: 0.31.1
 
 devDependencies:
   '@types/node':
@@ -773,26 +777,32 @@ packages:
       esutils: 2.0.3
     dev: true
 
-  /drizzle-orm@0.29.0:
-    resolution: {integrity: sha512-AC+CuW4GezVjsZDGU9u9B4HyikudOyYVhjm6he3Xn1D6Kky7bHGKob97MMX2piO+t9b6UuajLzlii/T/lu1qwA==}
+  /drizzle-orm@0.31.1:
+    resolution: {integrity: sha512-hTbYne2XX3y6sV7WSxcPH6/vNSiQSUG9VZsFI27jBMCN0OT3Ok7ao3pIT5OMAqWkzJCRFgGjAaUeTAZWPgOKag==}
     peerDependencies:
       '@aws-sdk/client-rds-data': '>=3'
       '@cloudflare/workers-types': '>=3'
+      '@electric-sql/pglite': '>=0.1.1'
       '@libsql/client': '*'
       '@neondatabase/serverless': '>=0.1'
+      '@op-engineering/op-sqlite': '>=2'
       '@opentelemetry/api': ^1.4.1
       '@planetscale/database': '>=1'
       '@types/better-sqlite3': '*'
       '@types/pg': '*'
+      '@types/react': '>=18'
       '@types/sql.js': '*'
-      '@vercel/postgres': '*'
+      '@vercel/postgres': '>=0.8.0'
+      '@xata.io/client': '*'
       better-sqlite3: '>=7'
       bun-types: '*'
+      expo-sqlite: '>=13.2.0'
       knex: '*'
       kysely: '*'
       mysql2: '>=2'
       pg: '>=8'
       postgres: '>=3'
+      react: '>=18'
       sql.js: '>=1'
       sqlite3: '>=5'
     peerDependenciesMeta:
@@ -800,9 +810,13 @@ packages:
         optional: true
       '@cloudflare/workers-types':
         optional: true
+      '@electric-sql/pglite':
+        optional: true
       '@libsql/client':
         optional: true
       '@neondatabase/serverless':
+        optional: true
+      '@op-engineering/op-sqlite':
         optional: true
       '@opentelemetry/api':
         optional: true
@@ -812,13 +826,19 @@ packages:
         optional: true
       '@types/pg':
         optional: true
+      '@types/react':
+        optional: true
       '@types/sql.js':
         optional: true
       '@vercel/postgres':
         optional: true
+      '@xata.io/client':
+        optional: true
       better-sqlite3:
         optional: true
       bun-types:
+        optional: true
+      expo-sqlite:
         optional: true
       knex:
         optional: true
@@ -829,6 +849,8 @@ packages:
       pg:
         optional: true
       postgres:
+        optional: true
+      react:
         optional: true
       sql.js:
         optional: true
@@ -1975,7 +1997,3 @@ packages:
     resolution: {integrity: sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==}
     engines: {node: '>=12.20'}
     dev: true
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false

--- a/src/__tests__/pg/_pg.test.ts
+++ b/src/__tests__/pg/_pg.test.ts
@@ -158,10 +158,11 @@ async function indexesTest() {
       compositePk: primaryKey(tbl.f1, tbl.f2),
       unique1: unique('key_1').on(tbl.f1),
       unique2: unique('key_2').on(tbl.f1, tbl.f2),
-      unique3: uniqueIndex('key_3').on(tbl.f2),
-      index1: index('key_4').on(tbl.f3),
+      unique3: uniqueIndex('key_3').on(tbl.f2.asc()),
+      index1: index('key_4').on(tbl.f3.desc()),
       index2: index('key_5').on(tbl.f3, tbl.f4),
-      index3: index().on(tbl.f4)
+      index3: index('key_6').on(tbl.f1.nullsFirst().desc()),
+      index4: index().on(tbl.f4)
     })
   );
 

--- a/src/__tests__/pg/_pg.test.ts
+++ b/src/__tests__/pg/_pg.test.ts
@@ -29,7 +29,7 @@ import {
 } from 'drizzle-orm/pg-core';
 import { compareContents } from '../utils';
 import { pgGenerate } from '~/generators';
-import { relations } from 'drizzle-orm';
+import { relations, sql } from 'drizzle-orm';
 
 const pathPrefix = './src/__tests__/pg/';
 
@@ -162,7 +162,8 @@ async function indexesTest() {
       index1: index('key_4').on(tbl.f3.desc()),
       index2: index('key_5').on(tbl.f3, tbl.f4),
       index3: index('key_6').on(tbl.f1.nullsFirst().desc()),
-      index4: index().on(tbl.f4)
+      index4: index().on(tbl.f4),
+      index5: index('key_7').using('btree', tbl.f1.asc(), sql`lower(${tbl.f2})`)
     })
   );
 

--- a/src/__tests__/pg/indexes.dbml
+++ b/src/__tests__/pg/indexes.dbml
@@ -13,5 +13,6 @@ table table {
     (f3, f4) [name: 'key_5']
     f1 [name: 'key_6']
     f4
+    (f1, f2) [name: 'key_7']
   }
 }

--- a/src/__tests__/pg/indexes.dbml
+++ b/src/__tests__/pg/indexes.dbml
@@ -11,6 +11,7 @@ table table {
     f2 [name: 'key_3', unique]
     f3 [name: 'key_4']
     (f3, f4) [name: 'key_5']
+    f1 [name: 'key_6']
     f4
   }
 }

--- a/src/generators/common.ts
+++ b/src/generators/common.ts
@@ -17,7 +17,8 @@ import {
   PgEnum,
   PrimaryKey as PgPrimaryKey,
   UniqueConstraint as PgUniqueConstraint,
-  isPgEnum
+  isPgEnum,
+  ExtraConfigColumn
 } from 'drizzle-orm/pg-core';
 import {
   ForeignKey as MySqlForeignKey,
@@ -139,6 +140,12 @@ export abstract class BaseGenerator<
     const columns = getTableColumns(table as unknown as Table);
     for (const columnName in columns) {
       const column = columns[columnName];
+      // (HACK):: Inject defaults found here (which otherwise do not exist): https://github.com/drizzle-team/drizzle-orm/blob/3513d0a76f8a227a3f94673762ae73538fd849bc/drizzle-orm/src/pg-core/columns/common.ts#L153-L156
+      (column as ExtraConfigColumn).defaultConfig = {
+        order: 'asc',
+        nulls: 'last',
+        opClass: undefined
+      };
       const columnDBML = this.generateColumn(column as Column);
       dbml.insert(columnDBML).newLine();
     }

--- a/src/generators/common.ts
+++ b/src/generators/common.ts
@@ -9,7 +9,8 @@ import {
   getTableColumns,
   is,
   isTable,
-  Table
+  Table,
+  Column
 } from 'drizzle-orm';
 import {
   AnyInlineForeignKeys,
@@ -173,8 +174,12 @@ export abstract class BaseGenerator<
         dbml.tab(2);
 
         if (is(index, PgIndex) || is(index, MySqlIndex) || is(index, SQLiteIndex)) {
+          const configColumns = index.config.columns.flatMap((entry) =>
+            is(entry, SQL) ? entry.queryChunks.filter((v) => is(v, Column)) : entry
+          );
+
           const idxColumns = wrapColumns(
-            index.config.columns as AnyColumn[],
+            configColumns as AnyColumn[],
             this.buildQueryConfig.escapeName
           );
           const idxProperties = index.config.name

--- a/src/generators/common.ts
+++ b/src/generators/common.ts
@@ -156,10 +156,7 @@ export abstract class BaseGenerator<
       extraConfig = extraConfigBuilder?.(table);
     }
 
-    const builtIndexes = Object.values(extraConfig || {}).map((b: AnyBuilder) => {
-      console.log('Rush b', b);
-      return b.build(table);
-    });
+    const builtIndexes = Object.values(extraConfig || {}).map((b: AnyBuilder) => b.build(table));
     const fks = builtIndexes.filter(
       (index) =>
         is(index, PgForeignKey) || is(index, MySqlForeignKey) || is(index, SQLiteForeignKey)

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -5,3 +5,4 @@ export const SQLiteInlineForeignKeys = Symbol.for('drizzle:SQLiteInlineForeignKe
 export const TableName = Symbol.for('drizzle:Name');
 export const Schema = Symbol.for('drizzle:Schema');
 export const ExtraConfigBuilder = Symbol.for('drizzle:ExtraConfigBuilder');
+export const ExtraConfigColumns = Symbol.for('drizzle:ExtraConfigColumns');

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,7 +4,8 @@ import type {
   AnyInlineForeignKeys,
   TableName,
   Schema as SchemaSymbol,
-  ExtraConfigBuilder
+  ExtraConfigBuilder,
+  ExtraConfigColumns
 } from './symbols';
 
 export type AnyTable = Table['_']['columns'] & {
@@ -14,6 +15,7 @@ export type AnyTable = Table['_']['columns'] & {
   [ExtraConfigBuilder]:
     | ((self: Record<string, AnyColumn>) => Record<string, AnyBuilder>)
     | undefined;
+  [ExtraConfigColumns]: Record<string, AnyColumn> | undefined;
 };
 
 export type AnyBuilder = {


### PR DESCRIPTION
Drizzle [0.31.0 introduced a breaking change](https://github.com/drizzle-team/drizzle-orm/releases/tag/0.31.0) to the Postgres indexes API. The lack of support in `drizzle-dbml-generator` for enriched "extra config" columns led to two failure scenarios with the current build:
1. Unrecognised ordering options in extra config e.g. `tbl.f1.asc()` (`asc()` not found in standard column type)
2. Inability for the underlying `drizzle-orm` calls to use the indexes. JSON parsing would fail since the `defaultConfig` on a given column wasn't being set or enriched.

### What has changed
- Update `drizzle-orm` dev-dependency to the latest version (`0.31.1`)
- Extract richer / correct extra config for columns via a new `ExtraConfigColumns` symbol. This is specific to Postgres but functionally works in a dialect-agnostic way.
- Re-word _`extraConfig`_ → `extraConfigBuilder` to make language clearer and more accurate
- Add some more tests for the new API

---
resolves #12 
