### PR TITLE
Bypass Undefined Columns in ExtrConfigColumns

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "typings": "dist/index.d.ts",
   "type": "module",
   "scripts": {
+    "prepare": "npm run build",
     "build": "npx tsup src/index.ts --format cjs,esm --dts",
     "fmt": "npx prettier --write .",
     "lint": "npx eslint . && npx tsc --noEmit",

--- a/src/generators/common.ts
+++ b/src/generators/common.ts
@@ -152,7 +152,7 @@ export abstract class BaseGenerator<
     }
     const extraConfigBuilder = table[ExtraConfigBuilder];
     const extraConfigColumns = table[ExtraConfigColumns];
-    const extraConfig = extraConfigBuilder?.(extraConfigColumns ?? {});
+    const extraConfig = extraConfigColumns ? extraConfigBuilder?.(extraConfigColumns ?? {}) : {};
 
     const builtIndexes = Object.values(extraConfig ?? {}).map((b: AnyBuilder) => b.build(table));
     const fks = builtIndexes.filter(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,7 +15,7 @@ export function formatList(
 
 export function wrapColumns(columns: AnyColumn[], escapeName: (name: string) => string) {
   const formatted = formatList(
-    columns.map((column) => column.name),
+    columns.filter((column) => column !== undefined).map((column) => column.name),
     escapeName,
     true
   );


### PR DESCRIPTION

[Extra Config Builder chokes if there are not extra config columns. #14](https://github.com/L-Mario564/drizzle-dbml-generator/issues/14)

If you would rather me fix these errors in a different way I am happy to dig into it. 

This looks like a fun project. 