### PR TITLE
fix: added robust type-safety for extraConfig in generateTable

### DIFF
--- a/src/generators/common.ts
+++ b/src/generators/common.ts
@@ -156,7 +156,10 @@ export abstract class BaseGenerator<
     const extraConfigColumns = table[ExtraConfigColumns];
     const extraConfig = extraConfigBuilder?.(extraConfigColumns ?? {});
 
-    const builtIndexes = Object.values(extraConfig ?? {}).map((b: AnyBuilder) => b.build(table));
+    const builtIndexes = Object.values(extraConfig ?? {}).map((b) =>
+      typeof b?.build === 'function' ? b.build(table) : null
+    ).filter(Boolean);
+
     const fks = builtIndexes.filter(
       (index) =>
         is(index, PgForeignKey) || is(index, MySqlForeignKey) || is(index, SQLiteForeignKey)


### PR DESCRIPTION
I was getting this issue when trying to generate from my postgres table. This PR fixes an issue where b.build is not a function in generateTable by checking if build exists and is a function before calling it.
