### PR TITLE
fix: support drizzle-orm 0.40+ pgTable index syntax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 dist
 *.generated.dbml
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drizzle-dbml-generator",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Convert your Drizzle ORM schema into DBML markup",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/src/__tests__/pg/_pg.test.ts
+++ b/src/__tests__/pg/_pg.test.ts
@@ -176,6 +176,94 @@ async function indexesTest() {
   expect(result).toBe(true);
 }
 
+async function indexesAsArrayTest() {
+  const table = pgTable(
+    'table',
+    {
+      f1: integer('f1'),
+      f2: integer('f2'),
+      f3: integer('f3'),
+      f4: integer('f4')
+    },
+    (tbl) => [primaryKey(tbl.f1, tbl.f2),
+      unique('key_1').on(tbl.f1),
+      unique('key_2').on(tbl.f1, tbl.f2),
+      uniqueIndex('key_3').on(tbl.f2.asc()),
+      index('key_4').on(tbl.f3.desc()),
+      index('key_5').on(tbl.f3, tbl.f4),
+      index('key_6').on(tbl.f1.nullsFirst().desc()),
+      index().on(tbl.f4),
+      index('key_7').using('btree', tbl.f1.asc(), sql`lower(${tbl.f2})`)
+    ]
+  );
+
+  const schema = { table };
+  const out = `${pathPrefix}indexes.generated.dbml`;
+  pgGenerate({ schema, out });
+
+  const result = await compareContents(out);
+  expect(result).toBe(true);
+}
+
+async function indexesAsObjectTest() {
+  const table = pgTable(
+    'table',
+    {
+      f1: integer('f1'),
+      f2: integer('f2'),
+      f3: integer('f3'),
+      f4: integer('f4')
+    },
+    (tbl) => [{ pk: primaryKey(tbl.f1, tbl.f2)},
+      { unique: unique('key_1').on(tbl.f1) },
+      { unique: unique('key_2').on(tbl.f1, tbl.f2) },
+      { uniqueIndex: uniqueIndex('key_3').on(tbl.f2.asc()) },
+      { index: index('key_4').on(tbl.f3.desc()) },
+      { index: index('key_5').on(tbl.f3, tbl.f4) },
+      { index: index('key_6').on(tbl.f1.nullsFirst().desc()) },
+      { index: index().on(tbl.f4) },
+      { index: index('key_7').using('btree', tbl.f1.asc(), sql`lower(${tbl.f2})`) }
+    ]
+  );
+
+  const schema = { table };
+  const out = `${pathPrefix}indexes.generated.dbml`;
+  pgGenerate({ schema, out });
+
+  const result = await compareContents(out);
+  expect(result).toBe(true);
+}
+
+async function indexesAsSingleObjectTest() {
+  const table = pgTable(
+    'table',
+    {
+      f1: integer('f1'),
+      f2: integer('f2'),
+      f3: integer('f3'),
+      f4: integer('f4')
+    },
+    (tbl) => [{
+      pk: primaryKey(tbl.f1, tbl.f2),
+      unique1: unique('key_1').on(tbl.f1),
+      unique2: unique('key_2').on(tbl.f1, tbl.f2),
+      uniqueIndex: uniqueIndex('key_3').on(tbl.f2.asc()),
+      index1: index('key_4').on(tbl.f3.desc()),
+      index2: index('key_5').on(tbl.f3, tbl.f4),
+      index3: index('key_6').on(tbl.f1.nullsFirst().desc()),
+      index4: index().on(tbl.f4),
+      index5: index('key_7').using('btree', tbl.f1.asc(), sql`lower(${tbl.f2})`)
+    }]
+  );
+
+  const schema = { table };
+  const out = `${pathPrefix}indexes.generated.dbml`;
+  pgGenerate({ schema, out });
+
+  const result = await compareContents(out);
+  expect(result).toBe(true);
+}
+
 async function schemasTest() {
   const schema1 = pgSchema('schema1');
   const schema2 = pgSchema('schema2');
@@ -385,6 +473,9 @@ describe('Postgres dialect tests', () => {
   it('Outputs an inline foreign key', inlineFkTest);
   it('Outputs a foreign key', fkTest);
   it('Outputs all indexes', indexesTest);
+  it('Outputs all indexes when using array syntax', indexesAsArrayTest);
+  it('Outputs all indexes when using object syntax', indexesAsObjectTest);
+  it('Outputs all indexes when using single object syntax', indexesAsSingleObjectTest);
   it('Outputs tables with different schemas', schemasTest);
   it('Outputs relations written with the RQB API', rqbTest);
   it('Outputs tables with different schemas with the RQB API', schemasRQBTest);

--- a/src/generators/common.ts
+++ b/src/generators/common.ts
@@ -53,7 +53,13 @@ import type {
   SQLiteInlineForeignKeys
 } from '~/symbols';
 import type { AnyColumn, BuildQueryConfig } from 'drizzle-orm';
-import { isBuilderObj, isBuilderRecord, type AnyBuilder, type AnySchema, type AnyTable } from '~/types';
+import {
+  isBuilderObj,
+  isBuilderRecord,
+  type AnyBuilder,
+  type AnySchema,
+  type AnyTable
+} from '~/types';
 
 export abstract class BaseGenerator<
   Schema extends AnySchema = AnySchema,
@@ -162,23 +168,21 @@ export abstract class BaseGenerator<
     const extraConfig = extraConfigBuilder?.(extraConfigColumns ?? {});
 
     const builtIndexes = (
-  Array.isArray(extraConfig)
-    ? extraConfig
-    : Object.values(extraConfig ?? {})
-)
-  .flatMap((b: AnyBuilder) => {
-  if (isBuilderObj(b)) {
-    return [b.build(table)];
-  }
+      Array.isArray(extraConfig) ? extraConfig : Object.values(extraConfig ?? {})
+    )
+      .flatMap((b: AnyBuilder) => {
+        if (isBuilderObj(b)) {
+          return [b.build(table)];
+        }
 
-  if (isBuilderRecord(b)) {
-    return Object.values(b).map((builder) => builder.build(table));
-  }
+        if (isBuilderRecord(b)) {
+          return Object.values(b).map((builder) => builder.build(table));
+        }
 
-  return [];
-})
-  // The DBML markup language doesn't support check constraints
-  .filter((index) => !(is(index, PgCheck) || is(index, MySqlCheck) || is(index, SQLiteCheck)));
+        return [];
+      })
+      // The DBML markup language doesn't support check constraints
+      .filter((index) => !(is(index, PgCheck) || is(index, MySqlCheck) || is(index, SQLiteCheck)));
     const fks = builtIndexes.filter(
       (index) =>
         is(index, PgForeignKey) || is(index, MySqlForeignKey) || is(index, SQLiteForeignKey)

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,7 +28,7 @@ export function isBuilderObj(val: unknown): val is BuilderObj {
   return typeof val === 'object' && val !== null && typeof (val as any).build === 'function';
 }
 
-  /** In drizzle-orm 0.40+, pgTable is now an array of keyed Builder objects. */
+/** In drizzle-orm 0.40+, pgTable is now an array of keyed Builder objects. */
 export type BuilderRecord = Record<string, BuilderObj>;
 export function isBuilderRecord(val: unknown): val is BuilderRecord {
   if (typeof val !== 'object' || val === null) return false;
@@ -36,9 +36,7 @@ export function isBuilderRecord(val: unknown): val is BuilderRecord {
   // Make sure that every value in the record is a BuilderObj.
   return Object.values(val).every(
     (entry) =>
-      typeof entry === 'object' &&
-      entry !== null &&
-      typeof (entry as any).build === 'function'
+      typeof entry === 'object' && entry !== null && typeof (entry as any).build === 'function'
   );
 }
 


### PR DESCRIPTION
It looks like the index syntax is being moved over to an array instead of an object: https://orm.drizzle.team/docs/indexes-constraints

In 0.40+, users see a deprecated warning for `pgTable` when using object syntax. See #30 for how this breaks DBML generation.

This PR adds support for the new pgTable syntax, adds tests, and bumps to 0.11.0. I didn't see a CONTRIBUTING.md, but I hope this is what you expect of external contributions. 